### PR TITLE
Target Multi Frameworks. Added .net core 3.0

### DIFF
--- a/AzureFunctions.VisualStudioGallery/AzureFunctions.VisualStudioGallery.csproj
+++ b/AzureFunctions.VisualStudioGallery/AzureFunctions.VisualStudioGallery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46;netcoreapp3.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>0.1.4</Version>
     <Authors>kzu</Authors>


### PR DESCRIPTION
Amazing project!  I was able to use easily the nuget with Azure V1  servers. 

The need for the addition of MultiFrameworks is to be able to create a nuget for .net Core 3.0 and use it on Azure V3 Servers.  No server in Canada surrports Azure v1 and as businesses don't want to have their data out of the country, everything needs to stay home.

So for the Pull Request:
One line changed to be able to target .net core 3.0 and create the nuget for that Framework at the same time as the nuget for .net framework 4.6.  This aims to have the code usable in Azure .net v3 servers.

Since Tests seems to be bound to your account, if you could run them again, to make sure everything is still all right, that would be appreciated.  

Same for the nuget version .net Core 3.0  I think it needs to be deployed by you.  

If you have any questions, you can contact me anytime.